### PR TITLE
imprv Warning: Each child in a list should have a unique "key" prop. 

### DIFF
--- a/components/forms/SweetsDropDown.tsx
+++ b/components/forms/SweetsDropDown.tsx
@@ -8,7 +8,7 @@ type Props = {
 const SweetsDropDown: React.FC<Props> = React.memo(({ sweets }) => {
   const sweetsItems: JSX.Element[] = sweets.map((item: string) => {
     return (
-      <MenuItem id={item}>
+      <MenuItem id={item} key={item}>
         {item}
       </MenuItem>
     );


### PR DESCRIPTION
imprv warning below

Warning: Each child in a list should have a unique "key" prop.

Check the top-level render call using <WithStyles(ForwardRef(Select))>. See https://reactjs.org/link/warning-keys for more information.
    at WithStyles (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
    at Controller (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/react-hook-form/dist/index.cjs.development.js:1783:71)
    at react__WEBPACK_IMPORTED_MODULE_1___default.a.memo (webpack-internal:///./components/forms/SweetsDropDown.tsx:16:87)
    at react__WEBPACK_IMPORTED_MODULE_1___default.a.memo (webpack-internal:///./components/forms/SweetsDropDown.tsx:16:87)
    at form
    at FormProvider (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/react-hook-form/dist/index.cjs.development.js:1395:24)
    at NewReviewForm (webpack-internal:///./components/forms/NewReviewForm.tsx:29:23)
    at div
    at Container (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/@material-ui/core/Container/Container.js:92:23)
    at WithStyles (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
    at Top
    at App (webpack-internal:///./pages/_app.tsx:26:13)
    at AppContainer (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/next/dist/next-server/server/render.js:23:746)
Warning: Failed prop type: Material-UI: The prop `name` is required (when `readOnly` is false).
Additionally, the input name should be unique within the parent form.
    at Rating (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/@material-ui/lab/Rating/Rating.js:186:23)
    at WithStyles (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
    at Controller (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/react-hook-form/dist/index.cjs.development.js:1783:71)
    at EvaluationForm (webpack-internal:///./components/forms/EvaluetionForm.tsx:24:77)
    at form
    at FormProvider (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/react-hook-form/dist/index.cjs.development.js:1395:24)
    at NewReviewForm (webpack-internal:///./components/forms/NewReviewForm.tsx:29:23)
    at div
    at Container (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/@material-ui/core/Container/Container.js:92:23)
    at WithStyles (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/@material-ui/styles/withStyles/withStyles.js:67:31)
    at Top
    at App (webpack-internal:///./pages/_app.tsx:26:13)
    at AppContainer (/Users/kenta/Documents/ito-ocashi/ito-ocashi-review/node_modules/next/dist/next-server/server/render.js:23:746)